### PR TITLE
move pip cache above

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
           uses: actions/setup-python@v2
           with:
             python-version: ${{ matrix.py }}
+                    
+        - name: Cache pip
+          uses: actions/cache@v2
+          with:
+            path: ${{ env.pythonLocation }}
+            key: ${{ env.pythonLocation }}-cache
 
         - name: Install GSL, FFTW (linux)
           run: |
@@ -31,6 +37,8 @@ jobs:
         - name: Install python dependencies
           run: |
             python -m pip install -U pip
+            # Install wheel to avoid recompiling pymaster, pyccl, camb, etc.
+            pip install -U wheel
             pip install -U numpy
             pip install -U scipy
             pip install -U flake8
@@ -55,13 +63,3 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run:
             coveralls --service=github
-                    
-        - name: Cache pip
-          uses: actions/cache@v2
-          with:
-            path: |
-              ~/.cache/pip
-            key: ${{ runner.os }}-${{ matrix.py }}-cache
-            restore-keys: |
-              ${{ runner.os }}-${{ matrix.py }}-cache
-              ${{ runner.os }}-


### PR DESCRIPTION
I think the cache of pip is doing nothing because it's done after pip installation. Trying to move it before