### PR TITLE
Quick  code fixes

### DIFF
--- a/xcell/mappers/mapper_2MPZ.py
+++ b/xcell/mappers/mapper_2MPZ.py
@@ -137,8 +137,7 @@ class Mapper2MPZ(MapperBase):
 
     def get_mask(self):
         if self.mask is None:
-            self.mask = hp.ud_grade(hp.read_map(self.config['mask'],
-                                                verbose=False),
+            self.mask = hp.ud_grade(hp.read_map(self.config['mask']),
                                     nside_out=self.nside)
         return self.mask
 

--- a/xcell/mappers/mapper_DESY1gc.py
+++ b/xcell/mappers/mapper_DESY1gc.py
@@ -12,7 +12,7 @@ class MapperDESY1gc(MapperBase):
         Data source:
         https://des.ncsa.illinois.edu/releases/y1a1/key-catalogs/key-shape
         config - dict
-          {'data_catalogs':'/home/zcapjru/PhD/Data/DES_redm/DES_Y1A1_3x2pt_redMaGiC_zerr_CATALOG.fits',
+          {'data_catalog':'/home/zcapjru/PhD/Data/DES_redm/DES_Y1A1_3x2pt_redMaGiC_zerr_CATALOG.fits',
            'file_mask':'/home/zcapjru/PhD/Data/DES_redm/DES_Y1A1_3x2pt_redMaGiC_MASK_HPIX4096RING.fits',
            'file_nz':'/home/zcapjru/PhD/Data/DES_redm/2pt_NG_mcal_1110.fits',
            'zbin':1,
@@ -39,7 +39,7 @@ class MapperDESY1gc(MapperBase):
 
     def get_catalog(self):
         if self.cat_data is None:
-            self.cat_data = Table.read(self.config['data_catalogs'])
+            self.cat_data = Table.read(self.config['data_catalog'])
             self.cat_data = self._bin_z(self.cat_data)
         return self.cat_data
 
@@ -56,7 +56,7 @@ class MapperDESY1gc(MapperBase):
 
     def get_mask(self):
         if self.mask is None:
-            self.mask = hp.read_map(self.config['file_mask'], verbose=False)
+            self.mask = hp.read_map(self.config['file_mask'])
             self.mask = hp.ud_grade(self.mask, nside_out=self.nside)
             # Cap it
             goodpix = self.mask > self.mask_threshold

--- a/xcell/mappers/mapper_P18CMBK.py
+++ b/xcell/mappers/mapper_P18CMBK.py
@@ -59,8 +59,7 @@ class MapperP18CMBK(MapperBase):
                 fl = np.ones(lmax+1)
                 fl[3*self.nside:] = 0
                 self.klm = hp.almxfl(self.klm, fl, inplace=True)
-            self.signal_map = [hp.alm2map(self.klm, self.nside,
-                                          verbose=False)]
+            self.signal_map = [hp.alm2map(self.klm, self.nside)]
         return self.signal_map
 
     def get_mask(self):
@@ -70,7 +69,7 @@ class MapperP18CMBK(MapperBase):
                 self.mask = hp.read_map(fname, dtype=float)
             else:
                 self.mask = hp.read_map(self.config['file_mask'],
-                                        verbose=False, dtype=float)
+                                        dtype=float)
                 if self.rotate:
                     self.mask = self.r.rotate_map_pixel(self.mask)
                     # Binarize

--- a/xcell/mappers/mapper_SDSS.py
+++ b/xcell/mappers/mapper_SDSS.py
@@ -16,7 +16,7 @@ class MapperSDSS(MapperBase):
         self.SDSS_name = config['SDSS_name']
         self.path_lite = config.get('path_lite', None)
         self.cats = {'data': None, 'random': None}
-        self.z_arr_dim = config.get('z_arr_dim', 50)
+        self.num_z_bins = config.get('num_z_bins', 50)
         self.nside_mask = config.get('nside_mask', 512)
         self.npix = hp.nside2npix(self.nside)
         self.ws = {'data': None, 'random': None}
@@ -52,7 +52,7 @@ class MapperSDSS(MapperBase):
         if self.dndz is None:
             cat_data = self.get_catalog(mod='data')
             w_data = self._get_w(mod='data')
-            h, b = np.histogram(cat_data['Z'], bins=self.z_arr_dim,
+            h, b = np.histogram(cat_data['Z'], bins=self.num_z_bins,
                                 weights=w_data, range=self.z_edges)
             self.dndz = np.array([0.5 * (b[:-1] + b[1:]), h])
         z, nz = self.dndz

--- a/xcell/mappers/mapper_WIxSC.py
+++ b/xcell/mappers/mapper_WIxSC.py
@@ -180,16 +180,14 @@ class MapperWIxSC(MapperBase):
 
     def get_mask(self):
         if self.mask is None:
-            self.mask = hp.ud_grade(hp.read_map(self.config['mask'],
-                                                verbose=False),
+            self.mask = hp.ud_grade(hp.read_map(self.config['mask']),
                                     nside_out=self.nside)
         return self.mask
 
     def _get_stars(self):
         if self.stars is None:
             # Power = -2 makes sure the total number of stars is conserved
-            self.stars = hp.ud_grade(hp.read_map(self.config['star_map'],
-                                                 verbose=False),
+            self.stars = hp.ud_grade(hp.read_map(self.config['star_map']),
                                      nside_out=self.nside, power=-2)
             # Convert to stars per deg^2
             pix_srad = 4*np.pi/self.npix

--- a/xcell/mappers/mapper_dummy.py
+++ b/xcell/mappers/mapper_dummy.py
@@ -133,11 +133,10 @@ class MapperDummy(MapperBase):
             np.random.seed(self.seed)
             cl = self.get_cl()
             if self.spin == 0:
-                self.signal_map = [hp.synfast(cl, self.nside, verbose=False)]
+                self.signal_map = [hp.synfast(cl, self.nside)]
             elif self.spin == 2:
                 _, mq, mu = hp.synfast([0*cl, cl, 0*cl, 0*cl],
-                                       self.nside, new=True,
-                                       verbose=False)
+                                       self.nside, new=True)
                 self.signal_map = [mq, mu]
         return self.signal_map
 

--- a/xcell/tests/data/desy1_ebossqso_p18cmbk.yml
+++ b/xcell/tests/data/desy1_ebossqso_p18cmbk.yml
@@ -1,7 +1,7 @@
 tracers:
   # Biases from Table II of DES 5x2pt paper
   DESgc__0:
-    data_catalogs: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_zerr_CATALOG.fits'
+    data_catalog: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_zerr_CATALOG.fits'
     file_mask: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_MASK_HPIX4096RING.fits'
     file_nz: '/mnt/extraspace/damonge/S8z_data/DES_data/data_vector/2pt_NG_mcal_1110.fits'
     zbin: 0
@@ -14,7 +14,7 @@ tracers:
 
 
   DESgc__1:
-    data_catalogs: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_zerr_CATALOG.fits'
+    data_catalog: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_zerr_CATALOG.fits'
     file_mask: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_MASK_HPIX4096RING.fits'
     file_nz: '/mnt/extraspace/damonge/S8z_data/DES_data/data_vector/2pt_NG_mcal_1110.fits'
     zbin: 1
@@ -26,7 +26,7 @@ tracers:
     threshold: 0.5
   
   DESgc__2:
-    data_catalogs: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_zerr_CATALOG.fits'
+    data_catalog: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_zerr_CATALOG.fits'
     file_mask: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_MASK_HPIX4096RING.fits'
     file_nz: '/mnt/extraspace/damonge/S8z_data/DES_data/data_vector/2pt_NG_mcal_1110.fits'
     zbin: 2
@@ -38,7 +38,7 @@ tracers:
     threshold: 0.5
 
   DESgc__3:
-    data_catalogs: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_zerr_CATALOG.fits'
+    data_catalog: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_zerr_CATALOG.fits'
     file_mask: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_MASK_HPIX4096RING.fits'
     file_nz: '/mnt/extraspace/damonge/S8z_data/DES_data/data_vector/2pt_NG_mcal_1110.fits'
     zbin: 3
@@ -50,7 +50,7 @@ tracers:
     threshold: 0.5
     
   DESgc__4:
-    data_catalogs: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_zerr_CATALOG.fits'
+    data_catalog: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_zerr_CATALOG.fits'
     file_mask: '/mnt/extraspace/damonge/S8z_data/DES_data/redmagic_catalog/DES_Y1A1_3x2pt_redMaGiC_MASK_HPIX4096RING.fits'
     file_nz: '/mnt/extraspace/damonge/S8z_data/DES_data/data_vector/2pt_NG_mcal_1110.fits'
     zbin: 4

--- a/xcell/tests/test_mapper_dels.py
+++ b/xcell/tests/test_mapper_dels.py
@@ -8,7 +8,7 @@ def get_config():
                               'xcell/tests/data/catalog.fits'],
             'completeness_map': 'xcell/tests/data/map.fits',
             'binary_mask': 'xcell/tests/data/map.fits',
-            'z_arr_dim': 500,
+            'num_z_bins': 500,
             'star_map': 'xcell/tests/data/map.fits',
             'zbin': 0, 'nside': 32, 'mask_name': 'mask'}
 
@@ -27,7 +27,7 @@ def test_get_nz():
     m = get_mapper()
     z, nz = m.get_nz()
     h, b = np.histogram(m.cat_data[m.pz][m.mskflag],
-                        range=[-0.3, 1], bins=m.z_arr_dim)
+                        range=[-0.3, 1], bins=m.num_z_bins)
     z_arr = 0.5 * (b[:-1] + b[1:])
     sel = z_arr > 0
     assert len(z) == len(z_arr[sel])

--- a/xcell/tests/test_mapper_desy1gc.py
+++ b/xcell/tests/test_mapper_desy1gc.py
@@ -4,7 +4,7 @@ import healpy as hp
 
 
 def get_config():
-    return {'data_catalogs': 'xcell/tests/data/catalog.fits',
+    return {'data_catalog': 'xcell/tests/data/catalog.fits',
             'file_mask': 'xcell/tests/data/map.fits',
             'file_nz': 'xcell/tests/data/2pt_NG_mcal_1110.fits',
             'zbin': 2, 'nside': 32, 'mask_name': 'mask'}

--- a/xcell/tests/test_mapper_desy1wl.py
+++ b/xcell/tests/test_mapper_desy1wl.py
@@ -93,9 +93,9 @@ def test_lite():
                   f'PSF_w2s2_zbin{zbin}_ns{nside}.fits.gz']:
         assert os.path.isfile(os.path.join(plite, "DESwlMETACAL_" + fname))
 
-    # Check we recover the same mas and catalog
+    # Check we recover the same mask and catalog
     # Non-exsisting fits files - read from lite
-    config['data_catalogs'] = 'whatever'
+    config['data_cat'] = 'whatever'
     m_lite = xc.mappers.MapperDESY1wl(config)
     cat_from_lite = m_lite.get_catalog()
     s_from_lite = m_lite.get_signal_map()

--- a/xcell/tests/test_mapper_planck_all.py
+++ b/xcell/tests/test_mapper_planck_all.py
@@ -65,8 +65,8 @@ def test_get_cl_coupled(cls):
     mask = m.get_mask()
     cl_cross = m.get_cl_coupled()[0]
     nl_diff = m.get_nl_coupled()[0]
-    m1 = hp.read_map(conf['file_hm1'], verbose=False)
-    m2 = hp.read_map(conf['file_hm2'], verbose=False)
+    m1 = hp.read_map(conf['file_hm1'])
+    m2 = hp.read_map(conf['file_hm2'])
     cl_cross_bm = hp.anafast(m1*mask, m2*mask, iter=0)
     nl_diff_bm = hp.anafast(0.5*(m1-m2)*mask, iter=0)
     # Typical C_ell value for comparison (~1E-3 in this case)
@@ -87,9 +87,9 @@ def test_get_cls_covar_coupled(cls):
     m = cls(conf)
     mask = m.get_mask()
     cls_cov = m.get_cls_covar_coupled()
-    m1 = hp.read_map(conf['file_hm1'], verbose=False)
-    m2 = hp.read_map(conf['file_hm2'], verbose=False)
-    mc = hp.read_map(conf['file_map'], verbose=False)
+    m1 = hp.read_map(conf['file_hm1'])
+    m2 = hp.read_map(conf['file_hm2'])
+    mc = hp.read_map(conf['file_map'])
     cls_bm = {'cross': hp.anafast(mc*mask, mc*mask, iter=0),
               'auto_11': hp.anafast(m1*mask, m1*mask, iter=0),
               'auto_12': hp.anafast(m1*mask, m2*mask, iter=0),
@@ -108,8 +108,8 @@ def test_get_cls_covar_coupled(cls):
 def test_get_hm_maps(cls):
     conf = get_config()
     m = cls(conf)
-    m1b = hp.read_map(conf['file_hm1'], verbose=False)
-    m2b = hp.read_map(conf['file_hm2'], verbose=False)
+    m1b = hp.read_map(conf['file_hm1'])
+    m2b = hp.read_map(conf['file_hm2'])
     m1, m2 = m._get_hm_maps()
     assert np.all(m1 == m1b)
     assert np.all(m2 == m2b)


### PR DESCRIPTION
A few quick fixes while reviewing old code.
- Changed a few param names to make them more accurate/transparent.
- Removed several `verbose` options that now trigger an astropy warning.