### PR TITLE
Added correction to CatWISE density

### DIFF
--- a/xcell/mappers/mapper_CatWISE.py
+++ b/xcell/mappers/mapper_CatWISE.py
@@ -67,7 +67,7 @@ class MapperCatWISE(MapperBase):
                 ec_lat_map = 90-np.degrees(theta_EC)
                 
                 # this hard-coded number stems from the fit in 2009.14826
-                dens += 0.0513 / pixelarea_deg2 * np.abs(ec_lat_map)
+                dens += 0.0513 * np.abs(ec_lat_map)
                 # modity the number counts per pixel before computing density contrast below
                 nmap_data = dens * pixelarea_deg2
             ####


### PR DESCRIPTION
Corrected linear trend in source number density vs ecliptic latitude, as described in [2009.14826].  get_signal_map() comes with the keyword apply_galactic_correction=True to turn correction on/off.  If uncorrected this will affect quadrupole (and to a lesser degree power in higher, even multipoles)