### PR TITLE
fix requirements.txt git cloning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ flake8
 astropy
 healpy
 pandas
-git+git://github.com/LSSTDESC/NaMaster
+git+https://github.com/LSSTDESC/NaMaster
 pyccl
 camb
 sacc


### PR DESCRIPTION
Closes #203 

Basically it updated requirements.txt to the new GitHub security standards: https://github.blog/2021-09-01-improving-git-protocol-security-github/