### PR TITLE
Inverse-variance mask for ROSAT

### DIFF
--- a/xcell/mappers/mapper_ROSAT.py
+++ b/xcell/mappers/mapper_ROSAT.py
@@ -105,8 +105,8 @@ class MapperROSATXray(MapperBase):
         return signal_map
 
     def _get_mask(self):
-        mask = np.ones(self.npix)
         xpmap = self.get_expmap()
+        mask = xpmap.copy()
         mask[xpmap <= self.explimit] = 0
         if self.mask_external is not None:
             msk = hp.read_map(self.mask_external)

--- a/xcell/tests/test_mapper_rosat.py
+++ b/xcell/tests/test_mapper_rosat.py
@@ -99,6 +99,6 @@ def test_nl_coupled():
     m = xc.mappers.MapperROSATXray(c)
     nl = m.get_nl_coupled()
     apix = hp.nside2pixarea(c['nside'])
-    nl_guess = 1/(200.**2*apix)
+    nl_guess = 1/apix
     assert np.all(np.fabs(nl/nl_guess-1) < 1E-10)
     clean_rosat_data()


### PR DESCRIPTION
Using the exposure map itself as a mask for ROSAT (which is similar to inverse-variance noise weighting) leads to more homogeneous noise properties and smaller power spectrum uncertainties.