### PR TITLE
Fix noise and rerun when removing overlap

### DIFF
--- a/xcell/mappers/mapper_DELS.py
+++ b/xcell/mappers/mapper_DELS.py
@@ -85,7 +85,9 @@ class MapperDELS(MapperBase):
             catalog (Array)
         """
         if self.cat_data is None:
-            fn = f'{self.map_name}_cat.fits'
+            # This will handle the situation when removing the overlap
+            map_name = self.map_name.split("_")[0] + f"_bin{self.zbin}"
+            fn = f'{map_name}_cat.fits'
             self.cat_data = self._rerun_read_cycle(fn, 'FITSTable',
                                                    self._get_catalog)
         return self.cat_data

--- a/xcell/mappers/mapper_DESY1wl.py
+++ b/xcell/mappers/mapper_DESY1wl.py
@@ -263,6 +263,8 @@ class MapperDESY1wl(MapperBase):
                                             cat_data[e2f]**2),
                                      ra_name='ra', dec_name='dec',
                                      rot=self.rot)
+            msk = self.get_mask()
+            mp[msk == 0] = 0
             return mp
 
         fn = '_'.join([f'{self.map_name}_{mod}_w2s2',

--- a/xcell/mappers/mapper_HSC_DR1wl.py
+++ b/xcell/mappers/mapper_HSC_DR1wl.py
@@ -118,7 +118,9 @@ class MapperHSCDR1wl(MapperBase):
             cat (Array)
         """
         if self.cat is None:
-            fn = f'{self.map_name}.fits'
+            # This will handle the situation when removing the overlap
+            map_name = self.map_name.split("_")[0] + f"_{self.bn}"
+            fn = f'{map_name}.fits'
             self.cat = self._rerun_read_cycle(fn, 'FITSTable',
                                               self._get_catalog_from_raw)
         return self.cat

--- a/xcell/mappers/mapper_HSC_DR1wl.py
+++ b/xcell/mappers/mapper_HSC_DR1wl.py
@@ -227,6 +227,8 @@ class MapperHSCDR1wl(MapperBase):
                                       cat[self.w_name]**2),
                                    ra_name='ra', dec_name='dec',
                                    rot=self.rot)
+        msk = self.get_mask()
+        w2s2[msk == 0] = 0
         return w2s2
 
     def get_nl_coupled(self):

--- a/xcell/mappers/mapper_KV450.py
+++ b/xcell/mappers/mapper_KV450.py
@@ -228,6 +228,8 @@ class MapperKV450(MapperBase):
                                        ra_name='ALPHA_J2000',
                                        dec_name='DELTA_J2000',
                                        rot=self.rot)
+            msk = self.get_mask()
+            w2s2[msk == 0] = 0
             return w2s2
 
         fn = '_'.join([f'{self.map_name}_w2s2_{kind}',

--- a/xcell/mappers/mapper_KV450.py
+++ b/xcell/mappers/mapper_KV450.py
@@ -70,7 +70,9 @@ class MapperKV450(MapperBase):
             array: catalog data
         """
         if self.cat_data is None:
-            fn = f'{self.map_name}_cat.fits'
+            # This will handle the situation when removing the overlap
+            map_name = self.map_name.split("_")[0] + f"_bin{self.zbin}"
+            fn = f'{map_name}_cat.fits'
             self.cat_data = self._rerun_read_cycle(fn, 'FITSTable',
                                                    self._load_catalog,
                                                    saved_by_func=True)

--- a/xcell/mappers/mapper_KiDS1000.py
+++ b/xcell/mappers/mapper_KiDS1000.py
@@ -232,6 +232,8 @@ class MapperKiDS1000(MapperBase):
                                        ra_name='ALPHA_J2000',
                                        dec_name='DELTA_J2000',
                                        rot=self.rot)
+            msk = self.get_mask()
+            w2s2[msk == 0] = 0
             return w2s2
 
         fn = '_'.join([f'{self.map_name}_w2s2_{kind}',

--- a/xcell/mappers/mapper_KiDS1000.py
+++ b/xcell/mappers/mapper_KiDS1000.py
@@ -72,7 +72,9 @@ class MapperKiDS1000(MapperBase):
             cat_data (Array)
         """
         if self.cat_data is None:
-            fn = f'{self.map_name}_cat.fits'
+            # This will handle the situation when removing the overlap
+            map_name = self.map_name.split("_")[0] + f"_bin{self.zbin}"
+            fn = f'{map_name}_cat.fits'
             self.cat_data = self._rerun_read_cycle(fn, 'FITSTable',
                                                    self._load_catalog,
                                                    saved_by_func=True)

--- a/xcell/mappers/mapper_WIxSC.py
+++ b/xcell/mappers/mapper_WIxSC.py
@@ -105,7 +105,9 @@ class MapperWIxSC(MapperBase):
 
     def get_catalog(self):
         if self.cat_data is None:
-            fn = f'{self.map_name}_rerun_coord{self.coords}.fits'
+            # This will handle the situation when removing the overlap
+            map_name = self.map_name.split("_")[0] + f"_bin{self.zbin}"
+            fn = f'{map_name}_rerun_coord{self.coords}.fits'
             self.cat_data = self._rerun_read_cycle(fn, 'FITSTable',
                                                    self._get_catalog)
         return self.cat_data


### PR DESCRIPTION
Closes #265, #266 and similar bugs. Fixes the noise and the catalog rerun paths when removing the overlap.